### PR TITLE
Create API binding to Foreman 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source "http://rubygems.org"
 
 gem 'rake'
 gem 'apipie-bindings'
+gem "yaml"
+gem "ostruct"
+gem "pathname"
 
 group :test do
   gem 'rspec'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,6 @@
+api_url: 'http://foreman/'
+api_version: 2
+consumer_key: 'katelo'
+consumer_secret: 'sssh'
+timeout: 2
+api_user: 'admin'

--- a/lib/foregit.rb
+++ b/lib/foregit.rb
@@ -1,0 +1,6 @@
+module Foregit
+
+  require_relative 'settings'
+  ::SETTINGS = Settings.load_from_file
+
+end

--- a/lib/foregit.rb
+++ b/lib/foregit.rb
@@ -1,6 +1,6 @@
 module Foregit
 
   require_relative 'settings'
-  ::SETTINGS = Settings.load_from_file
+  SETTINGS = Settings.load_from_file
 
 end

--- a/lib/foreman/api.rb
+++ b/lib/foreman/api.rb
@@ -1,0 +1,19 @@
+require 'apipie-bindings'
+
+class API
+
+  def initialize
+    @api ||= ApipieBindings::API.new({
+      :uri => Settings[:api_url],
+      :api_version => Settings[:api_version],
+      :oauth => {
+        :consumer_key    => Settings[:consumer_key],
+        :consumer_secret => Settings[:consumer_secret]
+      },
+      :timeout => Settings[:timeout],
+      :headers => {
+        :foreman_user => Settings[:api_user]
+      }})
+  end
+
+end

--- a/lib/foreman/api.rb
+++ b/lib/foreman/api.rb
@@ -1,19 +1,26 @@
 require 'apipie-bindings'
 
-class API
+require_relative '../foregit'
 
-  def initialize
-    @api ||= ApipieBindings::API.new({
-      :uri => Settings[:api_url],
-      :api_version => Settings[:api_version],
-      :oauth => {
-        :consumer_key    => Settings[:consumer_key],
-        :consumer_secret => Settings[:consumer_secret]
-      },
-      :timeout => Settings[:timeout],
-      :headers => {
-        :foreman_user => Settings[:api_user]
-      }})
+class Foreman
+
+  class Api
+    include Foregit
+
+    def initialize
+      @api ||= ApipieBindings::API.new({
+        :uri => Foregit::SETTINGS[:api_url],
+        :api_version => Foregit::SETTINGS[:api_version],
+        :oauth => {
+          :consumer_key    => Foregit::SETTINGS[:consumer_key],
+          :consumer_secret => Foregit::SETTINGS[:consumer_secret]
+        },
+        :timeout => Foregit::SETTINGS[:timeout],
+        :headers => {
+          :foreman_user => Foregit::SETTINGS[:api_user]
+        }})
+    end
+
   end
 
 end

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -1,0 +1,17 @@
+require "yaml"
+require "ostruct"
+require "pathname"
+
+class Settings < OpenStruct
+
+  def self.load_from_file(settings_path=nil)
+    if settings_path.nil?
+      settings_path = Pathname.new(__FILE__).join("..","..","config",
+                                                  "settings.yml")
+    end
+
+    settings = YAML.load(File.read(settings_path))
+    Settings.new(settings)
+  end
+
+end


### PR DESCRIPTION
## Need

``` gherkin
As a developer
I want to create a API class to connect to the Foreman instance
So that I can download/upload the configuration files
```
## Deliverables
- an API binding class which can be used to download or upload resources configurations between Foreman and the local project
## Solution
#### Prerequisites
- [Settings class example](https://github.com/theforeman/smart-proxy/blob/develop/lib/proxy/settings.rb)
- [how to use apipie-bindings for  Foreman](https://github.com/theforeman/puppet-foreman/blob/master/lib/puppet/provider/foreman_smartproxy/rest_v2.rb#L11-L21) & [call example](https://github.com/theforeman/puppet-foreman/blob/master/lib/puppet/provider/foreman_smartproxy/rest_v2.rb#L42-L45)
- [How to define an API class](https://github.com/opscode/chef/blob/master/lib/chef/api_client.rb)
#### TODO
- [x] create config file to store API credentials (and other configurations which we will need later on)
- [x] create main API class to connect through apipie-bindings to Foreman API
#### Files
-  lib/foreman/api.rb
- config/settings.yaml
- lib/settings.rb
#### Notes
- [peculiar aspect relevant this story]
#### #ETA [0-2]p
