### PR TITLE
Add hammer command to represent a new resource as a JSON file in the Git repo

### DIFF
--- a/lib/foreman/api.rb
+++ b/lib/foreman/api.rb
@@ -33,7 +33,6 @@ class Foreman
     # Returns a hash
     #   {:resource_name => array_of_resources_downloaded}
     def download_resources(resources=nil)
-
       resources = get_resources_to_download(resources)
       foreman_resources = Hash.new
 
@@ -47,7 +46,13 @@ class Foreman
 
     def call_action(name, action, data)
         name = name.to_sym if name.is_a? String
-        action = action.to_sym if action.is_a? String
+
+        if action.is_a? String
+          action = action.to_sym
+        elsif action.is_a? Array
+          action = action[0].to_sym
+        end
+
         @api.call(name, action, data)
     end
 

--- a/lib/hammer_cli_foregit.rb
+++ b/lib/hammer_cli_foregit.rb
@@ -1,6 +1,7 @@
 module HammerCLIForegit
 
   require 'foregit'
+  require 'hammer_cli_foregit/add'
   require 'hammer_cli_foregit/pull'
   require 'hammer_cli_foregit/push'
   require 'hammer_cli_foregit/abstract_command'

--- a/lib/hammer_cli_foregit/add.rb
+++ b/lib/hammer_cli_foregit/add.rb
@@ -1,0 +1,32 @@
+require 'hammer_cli_foregit/abstract_command'
+
+module HammerCLIForegit
+
+  class Add < HammerCLIForegit::AbstractCommand
+
+    option ['-r', '--resource'], 'RESOURCE', 'The Foreman resource type',
+      :format => HammerCLI::Options::Normalizers::List.new
+    option ['-f', '--file'], 'FILE', 'A JSON or YAML file to define resource attributes',
+      :format => HammerCLI::Options::Normalizers::File.new
+    option ['-a', '--attributes'], 'ATTRIBUTES', 'A string of resource attributes described as key=value pairs, ex: -a "name=i382,hosts=[]"',
+      :format => HammerCLI::Options::Normalizers::KeyValueList.new
+
+    validate_options do
+      option(:option_resource).required
+      any(:option_file, :option_attributes).required
+    end
+
+    def execute
+      super
+      puts "Creating JSON representation of #{option_resource} resource in Git repo..."
+      @talk.add option_resource, option_file || option_attributes
+      puts 'Done!'
+      HammerCLI::EX_OK
+    end
+  end
+
+end
+
+HammerCLI::MainCommand.subcommand 'add',
+  'Create a new JSON file in the Git repository for a specific resource, where its attributes are set from a file or key=value pairs',
+  HammerCLIForegit::Add

--- a/lib/hammer_cli_foregit/add.rb
+++ b/lib/hammer_cli_foregit/add.rb
@@ -5,9 +5,9 @@ module HammerCLIForegit
   class Add < HammerCLIForegit::AbstractCommand
 
     option ['-r', '--resource'], 'RESOURCE', 'The Foreman resource type',
-      :format => HammerCLI::Options::Normalizers::List.new
+      :format => String
     option ['-f', '--file'], 'FILE', 'A JSON or YAML file to define resource attributes',
-      :format => HammerCLI::Options::Normalizers::File.new
+      :format => HammerCLI::Options::Normalizers::JSONInput.new
     option ['-a', '--attributes'], 'ATTRIBUTES', 'A string of resource attributes described as key=value pairs, ex: -a "name=i382,hosts=[]"',
       :format => HammerCLI::Options::Normalizers::KeyValueList.new
 

--- a/lib/hammer_cli_foregit/add.rb
+++ b/lib/hammer_cli_foregit/add.rb
@@ -20,6 +20,7 @@ module HammerCLIForegit
       super
       puts "Creating JSON representation of #{option_resource} resource in Git repo..."
       @talk.add option_resource, option_file || option_attributes
+      @git_manager.commit("Sync #{option_resource}.")
       puts 'Done!'
       HammerCLI::EX_OK
     end

--- a/lib/hammer_cli_foregit/pull.rb
+++ b/lib/hammer_cli_foregit/pull.rb
@@ -11,7 +11,7 @@ module HammerCLIForegit
       super
       puts "Sync from Foreman #{option_resources || 'all'} resources to Git repository..."
       @talk.pull option_resources
-      @git_manager.commit("Sync #{option_resources || 'all'} resources")
+      @git_manager.commit("Sync #{option_resources || 'all'} resources.")
       puts 'Done!'
       HammerCLI::EX_OK
     end

--- a/lib/hammer_cli_foregit/push.rb
+++ b/lib/hammer_cli_foregit/push.rb
@@ -11,6 +11,12 @@ module HammerCLIForegit
       super
       puts "Syncing from Git repository #{option_resources || 'all'} resources to Foreman..."
       @talk.push option_resources
+
+      tag = Time.now.to_i.to_s
+      @git_manager.commit("Sync #{option_resources}. Tag: #{tag}")
+      @git_manager.git.add_tag(tag)
+      puts("Tagged repository with #{tag}.")
+
       puts 'Done!'
       HammerCLI::EX_OK
     end

--- a/lib/talk_commands.rb
+++ b/lib/talk_commands.rb
@@ -4,6 +4,7 @@ sync command
     - download(settings[resources])
     - file manager
 =end
+require 'active_support/inflector'
 require 'json'
 
 require 'file_manager'
@@ -76,7 +77,7 @@ module Foregit
         end
       end
 
-      call_action_for_resource_content(resource_type, :create, attributes)
+      call_action_for_resource_content(resource_type, :create, {ActiveSupport::Inflector.singularize(resource_type) => attributes})
       pull resource_type
     end
 

--- a/lib/talk_commands.rb
+++ b/lib/talk_commands.rb
@@ -25,10 +25,9 @@ module Foregit
     # Download resources from Foreman and save them as files in the Git repo
     def pull(foreman_resources=nil)
       resources = @binding.download_resources(foreman_resources)
-
       resources.each do |resource_type, resources_content|
         resources_content.each do |resource_content|
-          dump_resource_as_file(resource_type, resources_content)
+          dump_resource_as_file(resource_type, resource_content)
         end
       end
     end
@@ -100,7 +99,7 @@ module Foregit
 
     def dump_resource_as_file(resource_type, resource_content)
       parsed_resource = {:type => resource_type.to_s,
-                         :name => "#{resource_content["id"].to_s}_#{resource_content["name"].to_s}",
+                         :name => "#{resource_content['id']}_#{resource_content['name']}",
                          :content => resource_content}
       @file_manager.dump_object_as_file(parsed_resource)
     end

--- a/lib/talk_commands.rb
+++ b/lib/talk_commands.rb
@@ -4,6 +4,7 @@ sync command
     - download(settings[resources])
     - file manager
 =end
+require 'json'
 
 require 'file_manager'
 require 'git_manager'
@@ -82,6 +83,20 @@ module Foregit
       @git_manager.git.add_tag(tag)
       puts("Tagged repository with #{tag}.")
 
+    end
+
+    # Create a JSON respresentation in the Git repository for a new resource
+    # Check for a valid id for the given resource, create a file with the
+    # correct naming in the repository and dump attributes as JSON.
+    def add resource, attributes
+      if !attributes.is_a? Hash
+        begin
+          JSON.parse!(attributes)
+        rescue Exception => e
+          puts "Error while parsing attributes #{attributes} as valid JSON. Error: #{e}"
+          return
+        end
+      end
     end
 
     private

--- a/spec/unit/file_manager_spec.rb
+++ b/spec/unit/file_manager_spec.rb
@@ -83,7 +83,7 @@ describe Foregit::FileManager do
 
     context 'dumping a valid JSON in an existent file' do
 
-      it 'the file should contain the resource content' do
+      it 'should contain the resource content' do
         file = 'test.json'
         file_path = File.join(@repo_path, file)
         File.open(file_path, 'w') {}
@@ -95,14 +95,14 @@ describe Foregit::FileManager do
         }
 
         @manager.dump_object_as_file(resource, file)
-        expect(File.read(file_path)).to match(resource[:content].to_json)
+        expect(JSON.parse(File.read(file_path))).to match(JSON.parse(resource[:content].to_json))
 
       end
     end
 
     context 'dumping a valid JSON in an inexistent file' do
 
-      it 'the file should contain the resource content after is created' do
+      it 'should contain the resource content after is created' do
         architectures = build(:architectures)
         resource = {
             :type => 'architectures',
@@ -112,8 +112,7 @@ describe Foregit::FileManager do
 
         @manager.dump_object_as_file(resource)
         file_path = @manager.find_file('architectures/' + architectures.name + '.json')
-
-        expect(File.read(file_path)).to match(resource[:content].to_json)
+        expect(JSON.parse(File.read(file_path))).to match(JSON.parse(resource[:content].to_json))
 
       end
     end


### PR DESCRIPTION
Problem with apipie-bindings:

```
agrant@foregit:~$ hammer add -r architectures -f ceva
Creating JSON representation of architectures resource in Git repo...
Creating resource architectures with attributes: {"architecture"=>{"name"=>"x86", "operatingsystem_ids"=>[]}} to Foreman...
Error: 422 Unprocessable Entity

vagrant@foregit:~$ hammer add -r architectures -f ceva
Creating JSON representation of architectures resource in Git repo...
Creating resource architectures with attributes: {"name"=>"x86", "operatingsystem_ids"=>[]} to Foreman...
Error: ApipieBindings::MissingArgumentsError: name

vagrant@foregit:~$ hammer add -r architectures -f ceva
Creating JSON representation of architectures resource in Git repo...
Creating resource architectures with attributes: {"architectures"=>{"name"=>"x86", "operatingsystem_ids"=>[]}} to Foreman...
Error: ApipieBindings::MissingArgumentsError: name
```
